### PR TITLE
Include the block explorer url when a network is added to MetaMask

### DIFF
--- a/src/contexts/providers.context.tsx
+++ b/src/contexts/providers.context.tsx
@@ -202,6 +202,7 @@ const ProvidersProvider: FC<PropsWithChildren> = (props) => {
               chainId: hexValue(chain.chainId),
               chainName: getChainName(chain),
               rpcUrls: [chain.provider.connection.url],
+              blockExplorerUrls: [chain.explorerUrl],
             },
           ],
         })


### PR DESCRIPTION
Closes #131

### What does this PR does?

This PR includes the block explorer url when a network is added to MetaMask.
