### PR TITLE
Fix fee gas increase percentage and properly apply the `maxEtherBridge` limit

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,7 @@ export const PAGE_SIZE = 25;
 
 export const PENDING_TX_TIMEOUT = 30 * 60 * 1000; // 30min in ms
 
-export const BRIDGE_CALL_GAS_INCREASE_PERCENTAGE = 40; // 40%
+export const BRIDGE_CALL_GAS_INCREASE_PERCENTAGE = 20; // 20%
 
 export const REPORT_ERROR_FORM_ENTRIES = {
   url: "entry.2056392454",

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -186,7 +186,9 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
             from: destinationAddress,
           })
           .then((gasLimit) => {
-            const gasIncrease = gasLimit.div(BRIDGE_CALL_GAS_INCREASE_PERCENTAGE);
+            const gasIncrease = gasLimit
+              .div(BigNumber.from(100))
+              .mul(BRIDGE_CALL_GAS_INCREASE_PERCENTAGE);
 
             return gasLimit.add(gasIncrease);
           });

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -33,7 +33,7 @@ const Activity: FC = () => {
   const [lastLoadedItem, setLastLoadedItem] = useState(0);
   const [total, setTotal] = useState(0);
   const [wrongNetworkBridges, setWrongNetworkBridges] = useState<string[]>([]);
-  const [disabledBridges, setDisabledBridges] = useState<string[]>([]);
+  const [areBridgesDisabled, setAreBridgesDisabled] = useState<boolean>(false);
   const classes = useActivityStyles({ displayAll });
 
   const headerBorderObserved = useRef<HTMLDivElement>(null);
@@ -50,7 +50,7 @@ const Activity: FC = () => {
 
   const onClaim = (bridge: Bridge) => {
     if (bridge.status === "on-hold") {
-      setDisabledBridges((current) => [...current, bridge.id]);
+      setAreBridgesDisabled(true);
       claim({
         bridge,
       })
@@ -68,7 +68,6 @@ const Activity: FC = () => {
           });
         })
         .catch((error) => {
-          setDisabledBridges((current) => current.filter((id) => id !== bridge.id));
           if (isMetaMaskUserRejectedRequestError(error) === false) {
             void parseError(error).then((parsed) => {
               if (parsed === "wrong-network") {
@@ -82,6 +81,9 @@ const Activity: FC = () => {
               }
             });
           }
+        })
+        .finally(() => {
+          setAreBridgesDisabled(false);
         });
     }
   };
@@ -308,7 +310,7 @@ const Activity: FC = () => {
                         <BridgeCard
                           bridge={bridge}
                           networkError={wrongNetworkBridges.includes(bridge.id)}
-                          isFinaliseDisabled={disabledBridges.includes(bridge.id)}
+                          isFinaliseDisabled={areBridgesDisabled}
                           showFiatAmount={env !== undefined && env.fiatExchangeRates.areEnabled}
                           onClaim={() => onClaim(bridge)}
                         />

--- a/src/views/bridge-confirmation/bridge-confirmation.view.tsx
+++ b/src/views/bridge-confirmation/bridge-confirmation.view.tsx
@@ -244,13 +244,16 @@ const BridgeConfirmation: FC = () => {
                     setIsFadeVisible(false);
                   }
                   const isTokenEther = token.address === ethersConstants.AddressZero;
-                  const remainder = amount.add(newFee).sub(tokenBalance);
-                  const isRemainderPositive = !remainder.isNegative();
+                  const remainder = isTokenEther ? amount.add(newFee).sub(tokenBalance) : undefined;
+                  const isRemainderPositive = remainder ? !remainder.isNegative() : undefined;
                   const newMaxPossibleAmountConsideringFee =
-                    isTokenEther && isRemainderPositive ? amount.sub(remainder) : amount;
-                  const msTimeout = FADE_DURATION_IN_SECONDS * 1000;
+                    isTokenEther && remainder && isRemainderPositive
+                      ? amount.sub(remainder)
+                      : amount;
 
-                  const etherToken = getEtherToken(from);
+                  const msTimeout = FADE_DURATION_IN_SECONDS * 1000;
+                  const etherToken = isTokenEther ? token : getEtherToken(from);
+
                   const hasOnScreenFeeChanged =
                     isAsyncTaskDataAvailable(oldFee) &&
                     formatTokenAmount(oldFee.data, etherToken) !==

--- a/src/views/home/components/amount-input/amount-input.view.tsx
+++ b/src/views/home/components/amount-input/amount-input.view.tsx
@@ -60,7 +60,10 @@ const AmountInput: FC<AmountInputProps> = ({
   };
 
   const handleMax = () => {
-    const maxPossibleAmount = balance.gt(maxEtherBridge) ? maxEtherBridge : balance;
+    const shouldApplyMaxEtherBridgeLimit =
+      token.address === ethers.constants.AddressZero && from.key === "ethereum";
+    const maxPossibleAmount =
+      shouldApplyMaxEtherBridgeLimit && balance.gt(maxEtherBridge) ? maxEtherBridge : balance;
     if (maxPossibleAmount.gt(0)) {
       setInputValue(formatTokenAmount(maxPossibleAmount, token));
       processOnChangeCallback(maxPossibleAmount);

--- a/src/views/home/components/bridge-form/bridge-form.view.tsx
+++ b/src/views/home/components/bridge-form/bridge-form.view.tsx
@@ -285,7 +285,7 @@ const BridgeForm: FC<BridgeFormProps> = ({
       setAmount(undefined);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connectedProvider, env]);
+  }, [connectedProvider]);
 
   useEffect(() => {
     // Load default form values


### PR DESCRIPTION
This PR fixes a bug in the gas limit increase calculation. According to the constant `BRIDGE_CALL_GAS_INCREASE_PERCENTAGE` set to `40`, we should be increasing the gas estimation by 40% but in reality, we were only increasing it by 2.5%.

We recently increased `BRIDGE_CALL_GAS_INCREASE_PERCENTAGE` from 20% to 40% because of this bug, so the original 20% is also restored.

Other changes included:
 * Avoid applying the `maxEtherBridge` limit to L2 deposits and ERC-20 tokens.
 * Avoid fading out/in the fee and the amount in the Bridge Confirmation screen when the new fee we obtain with the polling is changed so little that the value is visually the same due to the rounding we apply on screen.
 * Fix a bug that reset the form input after setting the value present in `FormData` when navigating from the Confirmation screen back to the Home screen.
 * Disable all bridge buttons when starting a bridge in the Activity screen.