### PR TITLE
Fix the broken provider error page

### DIFF
--- a/src/views/core/router/router.view.tsx
+++ b/src/views/core/router/router.view.tsx
@@ -9,13 +9,10 @@ import { useEnvContext } from "src/contexts/env.context";
 const Router: FC = () => {
   const env = useEnvContext();
 
-  if (!env) {
-    return null;
-  }
-
-  const filteredRoutes = areSettingsVisible(env)
-    ? routes
-    : Object.values(routes).filter((route) => route.path !== routes.settings.path);
+  const filteredRoutes =
+    !env || areSettingsVisible(env)
+      ? routes
+      : Object.values(routes).filter((route) => route.path !== routes.settings.path);
 
   return (
     <Routes>

--- a/src/views/network-error/network-error.styles.ts
+++ b/src/views/network-error/network-error.styles.ts
@@ -9,6 +9,7 @@ const useNetworkErrorStyles = createUseStyles((theme: Theme) => ({
     justifyContent: "center",
     flexDirection: "column",
     flex: 1,
+    marginBottom: theme.spacing(10),
   },
   logo: {
     width: "100%",


### PR DESCRIPTION
This PR fixes a bug that prevented the network error page from being displayed to the user when providers were unable to establish a connection to their RPCs.