### PR TITLE
Ignore MetaMask disconnect event after a network change

### DIFF
--- a/src/contexts/providers.context.tsx
+++ b/src/contexts/providers.context.tsx
@@ -54,11 +54,15 @@ const providersContext = createContext<ProvidersContext>({
 
 const ProvidersProvider: FC<PropsWithChildren> = (props) => {
   const navigate = useNavigate();
+  const env = useEnvContext();
+  const { notifyError } = useErrorContext();
   const [connectedProvider, setConnectedProvider] = useState<AsyncTask<ConnectedProvider, string>>({
     status: "pending",
   });
-  const env = useEnvContext();
-  const { notifyError } = useErrorContext();
+  // This is a hack to workaround this MetaMask issue:
+  // https://github.com/MetaMask/metamask-extension/issues/13375
+  const [isSwitchingNetwork, setIsSwitchingNetwork] = useState(false);
+  const IS_SWITCHING_NETWORK_DELAY = 1000;
 
   const getMetamaskProvider = () => {
     if (window.ethereum && window.ethereum.isMetaMask) {
@@ -188,6 +192,7 @@ const ProvidersProvider: FC<PropsWithChildren> = (props) => {
   );
 
   const switchNetwork = (chain: Chain, connectedProvider: Web3Provider): Promise<void> => {
+    setIsSwitchingNetwork(true);
     if (!connectedProvider.provider.request) {
       return Promise.reject(
         new Error("No request method is available from the provider to switch the Ethereum chain")
@@ -209,11 +214,17 @@ const ProvidersProvider: FC<PropsWithChildren> = (props) => {
         if (!isMetaMaskResourceUnavailableError(error)) {
           throw error;
         }
+      })
+      .finally(() => {
+        setTimeout(() => {
+          setIsSwitchingNetwork(false);
+        }, IS_SWITCHING_NETWORK_DELAY);
       });
   };
 
   const addNetwork = useCallback(
     (chain: Chain): Promise<void> => {
+      setIsSwitchingNetwork(true);
       const provider = getMetamaskProvider();
       if (!provider) {
         return Promise.reject(new Error("No provider is available"));
@@ -249,6 +260,11 @@ const ProvidersProvider: FC<PropsWithChildren> = (props) => {
           if (!isMetaMaskResourceUnavailableError(error)) {
             throw error;
           }
+        })
+        .finally(() => {
+          setTimeout(() => {
+            setIsSwitchingNetwork(false);
+          }, IS_SWITCHING_NETWORK_DELAY);
         });
     },
     [connectedProvider]
@@ -325,7 +341,9 @@ const ProvidersProvider: FC<PropsWithChildren> = (props) => {
     };
 
     const onDisconnect = () => {
-      setConnectedProvider({ status: "pending" });
+      if (!isSwitchingNetwork) {
+        setConnectedProvider({ status: "pending" });
+      }
     };
 
     if (externalProvider && "on" in externalProvider && typeof externalProvider.on === "function") {
@@ -345,7 +363,7 @@ const ProvidersProvider: FC<PropsWithChildren> = (props) => {
         externalProvider.removeListener(EthereumEvent.DISCONNECT, onDisconnect);
       }
     };
-  }, [connectProvider, connectedProvider, navigate]);
+  }, [connectedProvider, isSwitchingNetwork, connectProvider, navigate]);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
Closes #208 

### What does this PR does?

This PR workarounds [an issue with MetaMask](https://github.com/MetaMask/metamask-extension/issues/13375) by ignoring the MetaMask `disconnect` event for the first second after a network switch attempt occurs.