### PR TITLE
Revert amount param in the estimateBridgeGas fn

### DIFF
--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -49,7 +49,6 @@ interface EstimateBridgeGasParams {
   from: Chain;
   to: Chain;
   token: Token;
-  amount: BigNumber;
   destinationAddress: string;
 }
 
@@ -669,14 +668,9 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
   );
 
   const estimateBridgeGas = useCallback(
-    async ({
-      from,
-      to,
-      token,
-      amount,
-      destinationAddress,
-    }: EstimateBridgeGasParams): Promise<Gas> => {
+    async ({ from, to, token, destinationAddress }: EstimateBridgeGasParams): Promise<Gas> => {
       const contract = Bridge__factory.connect(from.bridgeContractAddress, from.provider);
+      const amount = BigNumber.from(0);
       const overrides: CallOverrides =
         token.address === ethersConstants.AddressZero
           ? { value: amount, from: destinationAddress }
@@ -740,7 +734,7 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
         value: token.address === ethersConstants.AddressZero ? amount : undefined,
         ...(gas
           ? gas.data
-          : (await estimateBridgeGas({ from, to, token, amount, destinationAddress })).data),
+          : (await estimateBridgeGas({ from, to, token, destinationAddress })).data),
       };
 
       const executeBridge = async () => {

--- a/src/views/bridge-confirmation/bridge-confirmation.view.tsx
+++ b/src/views/bridge-confirmation/bridge-confirmation.view.tsx
@@ -95,7 +95,6 @@ const BridgeConfirmation: FC = () => {
           from,
           to,
           token,
-          amount,
           destinationAddress,
         })
           .then((newGas) => {


### PR DESCRIPTION
### What does this PR does?

This PR reverts sending the `amount` param to the `estimateBridgeGas` fn to fix a bug when trying to bridge ERC-20 tokens.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [x] Update documentation (if needed)
