### PR TITLE
Fix ERR_CANCELED error and prevent extra request on activity and bridge details initial load

### DIFF
--- a/src/adapters/bridge-api.ts
+++ b/src/adapters/bridge-api.ts
@@ -237,6 +237,6 @@ export const getMerkleProof = ({
     });
 };
 
-export function isAxiosCancelRequestError(error: unknown): boolean {
+export function isCancelRequestError(error: unknown): boolean {
   return axios.isCancel(error);
 }

--- a/src/adapters/bridge-api.ts
+++ b/src/adapters/bridge-api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig } from "axios";
+import axios from "axios";
 import { z } from "zod";
 
 import { StrictSchema } from "src/utils/type-safety";
@@ -132,7 +132,7 @@ interface GetDepositsParams {
   ethereumAddress: string;
   limit?: number;
   offset?: number;
-  cancelToken?: AxiosRequestConfig["cancelToken"];
+  abortSignal?: AbortSignal;
 }
 
 export const getDeposits = ({
@@ -140,7 +140,7 @@ export const getDeposits = ({
   ethereumAddress,
   limit = PAGE_SIZE,
   offset = 0,
-  cancelToken,
+  abortSignal,
 }: GetDepositsParams): Promise<{
   deposits: DepositOutput[];
   total: number;
@@ -154,7 +154,7 @@ export const getDeposits = ({
         limit,
         offset,
       },
-      cancelToken,
+      signal: abortSignal,
     })
     .then((res) => {
       const parsedData = getDepositsResponseParser.safeParse(res.data);
@@ -233,3 +233,7 @@ export const getMerkleProof = ({
       }
     });
 };
+
+export function isAxiosCancelRequestError(error: unknown): boolean {
+  return axios.isCancel(error);
+}

--- a/src/adapters/bridge-api.ts
+++ b/src/adapters/bridge-api.ts
@@ -174,12 +174,14 @@ interface GetDepositParams {
   apiUrl: string;
   networkId: number;
   depositCount: number;
+  abortSignal?: AbortSignal;
 }
 
 export const getDeposit = ({
   apiUrl,
   networkId,
   depositCount,
+  abortSignal,
 }: GetDepositParams): Promise<DepositOutput> => {
   return axios
     .request({
@@ -190,6 +192,7 @@ export const getDeposit = ({
         net_id: networkId,
         deposit_cnt: depositCount,
       },
+      signal: abortSignal,
     })
     .then((res) => {
       const parsedData = getDepositResponseParser.safeParse(res.data);

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -43,7 +43,7 @@ interface EstimateBridgeGasParams {
   destinationAddress: string;
 }
 
-type GetBridgeParams = {
+type FetchBridgeParams = {
   env: Env;
   networkId: number;
   depositCount: number;
@@ -97,7 +97,7 @@ interface ClaimParams {
 interface BridgeContext {
   getMaxEtherBridge: (params: GetMaxEtherBridgeParams) => Promise<BigNumber>;
   estimateBridgeGas: (params: EstimateBridgeGasParams) => Promise<Gas>;
-  getBridge: (params: GetBridgeParams) => Promise<Bridge>;
+  fetchBridge: (params: FetchBridgeParams) => Promise<Bridge>;
   fetchBridges: (params: FetchBridgesParams) => Promise<{
     bridges: Bridge[];
     total: number;
@@ -116,7 +116,7 @@ const bridgeContext = createContext<BridgeContext>({
   estimateBridgeGas: () => {
     return Promise.reject(bridgeContextNotReadyErrorMsg);
   },
-  getBridge: () => {
+  fetchBridge: () => {
     return Promise.reject(bridgeContextNotReadyErrorMsg);
   },
   fetchBridges: () => {
@@ -149,8 +149,8 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
   type Price = BigNumber | null;
   type TokenPrices = Partial<Record<string, Price>>;
 
-  const getBridge = useCallback(
-    async ({ env, networkId, depositCount, abortSignal }: GetBridgeParams): Promise<Bridge> => {
+  const fetchBridge = useCallback(
+    async ({ env, networkId, depositCount, abortSignal }: FetchBridgeParams): Promise<Bridge> => {
       const apiUrl = env.bridgeApiUrl;
       const apiDeposit = await getDeposit({
         apiUrl,
@@ -864,7 +864,7 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
     () => ({
       getMaxEtherBridge,
       estimateBridgeGas,
-      getBridge,
+      fetchBridge,
       fetchBridges,
       getPendingBridges,
       bridge,
@@ -873,7 +873,7 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
     [
       getMaxEtherBridge,
       estimateBridgeGas,
-      getBridge,
+      fetchBridge,
       fetchBridges,
       getPendingBridges,
       bridge,

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -47,6 +47,7 @@ type GetBridgeParams = {
   env: Env;
   networkId: number;
   depositCount: number;
+  abortSignal?: AbortSignal;
 };
 
 interface GetBridgesParams {
@@ -149,12 +150,13 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
   type TokenPrices = Partial<Record<string, Price>>;
 
   const getBridge = useCallback(
-    async ({ env, networkId, depositCount }: GetBridgeParams): Promise<Bridge> => {
+    async ({ env, networkId, depositCount, abortSignal }: GetBridgeParams): Promise<Bridge> => {
       const apiUrl = env.bridgeApiUrl;
       const apiDeposit = await getDeposit({
         apiUrl,
         networkId,
         depositCount,
+        abortSignal,
       });
 
       const {

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -4,16 +4,7 @@ import {
   ContractTransaction,
   CallOverrides,
 } from "ethers";
-import axios, { AxiosRequestConfig } from "axios";
-import {
-  createContext,
-  FC,
-  useContext,
-  useCallback,
-  useRef,
-  useMemo,
-  PropsWithChildren,
-} from "react";
+import { createContext, FC, useContext, useCallback, useMemo, PropsWithChildren } from "react";
 
 import { useEnvContext } from "src/contexts/env.context";
 import { useProvidersContext } from "src/contexts/providers.context";
@@ -63,18 +54,20 @@ interface GetBridgesParams {
   ethereumAddress: string;
   limit: number;
   offset: number;
-  cancelToken?: AxiosRequestConfig["cancelToken"];
+  abortSignal?: AbortSignal;
 }
 
 interface RefreshBridgesParams {
   env: Env;
   ethereumAddress: string;
   quantity: number;
+  abortSignal?: AbortSignal;
 }
 
 type FetchBridgesParams = {
   env: Env;
   ethereumAddress: string;
+  abortSignal?: AbortSignal;
 } & (
   | {
       type: "load";
@@ -154,8 +147,6 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
 
   type Price = BigNumber | null;
   type TokenPrices = Partial<Record<string, Price>>;
-
-  const refreshCancelTokenSource = useRef(axios.CancelToken.source());
 
   const getBridge = useCallback(
     async ({ env, networkId, depositCount }: GetBridgeParams): Promise<Bridge> => {
@@ -291,7 +282,7 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
       ethereumAddress,
       limit,
       offset,
-      cancelToken,
+      abortSignal,
     }: GetBridgesParams): Promise<{
       bridges: Bridge[];
       total: number;
@@ -302,7 +293,7 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
         ethereumAddress,
         limit,
         offset,
-        cancelToken,
+        abortSignal,
       });
 
       const deposits = await Promise.all(
@@ -485,11 +476,11 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
       env,
       ethereumAddress,
       quantity,
+      abortSignal,
     }: RefreshBridgesParams): Promise<{
       bridges: Bridge[];
       total: number;
     }> => {
-      refreshCancelTokenSource.current = axios.CancelToken.source();
       const completePages = Math.floor(quantity / REFRESH_PAGE_SIZE);
       const remainderBridges = quantity % REFRESH_PAGE_SIZE;
       const requiredRequests = Math.max(
@@ -510,7 +501,7 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
                 ethereumAddress,
                 limit,
                 offset,
-                cancelToken: refreshCancelTokenSource.current.token,
+                abortSignal,
               });
             })
         )
@@ -530,19 +521,19 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
       total: number;
     }> => {
       if (params.type === "load") {
-        // fetching new data prevails over possible reloads in progress so we cancel them
-        refreshCancelTokenSource.current.cancel();
         return getBridges({
           env: params.env,
           ethereumAddress: params.ethereumAddress,
           limit: params.limit,
           offset: params.offset,
+          abortSignal: params.abortSignal,
         });
       } else {
         return refreshBridges({
           env: params.env,
           ethereumAddress: params.ethereumAddress,
           quantity: params.quantity,
+          abortSignal: params.abortSignal,
         });
       }
     },

--- a/src/contexts/env.context.tsx
+++ b/src/contexts/env.context.tsx
@@ -24,20 +24,22 @@ const EnvProvider: FC<PropsWithChildren> = (props) => {
   const location = useLocation();
 
   useEffect(() => {
-    loadEnv()
-      .then(setEnv)
-      .catch((e) => {
-        const error = providerError.safeParse(e);
+    if (!env) {
+      loadEnv()
+        .then(setEnv)
+        .catch((e) => {
+          const error = providerError.safeParse(e);
 
-        if (location.pathname !== routes.networkError.path) {
-          if (error.success) {
-            navigate(routes.networkError.path, { state: error.data });
-          } else {
-            notifyError(e);
+          if (location.pathname !== routes.networkError.path) {
+            if (error.success) {
+              navigate(routes.networkError.path, { state: error.data });
+            } else {
+              notifyError(e);
+            }
           }
-        }
-      });
-  }, [location, navigate, notifyError]);
+        });
+    }
+  }, [env, location, navigate, notifyError]);
 
   const value = useMemo(() => {
     return env;

--- a/src/contexts/tokens.context.tsx
+++ b/src/contexts/tokens.context.tsx
@@ -85,27 +85,15 @@ interface TokensContext {
   approve: (params: ApproveParams) => Promise<void>;
 }
 
-const tokensContextNotReadyMsg = "The bridge context is not yet ready";
+const tokensContextNotReadyMsg = "The tokens context is not yet ready";
 
 const tokensContext = createContext<TokensContext>({
-  addWrappedToken: () => {
-    return Promise.reject(tokensContextNotReadyMsg);
-  },
-  getTokenFromAddress: () => {
-    return Promise.reject(tokensContextNotReadyMsg);
-  },
-  getToken: () => {
-    return Promise.reject(tokensContextNotReadyMsg);
-  },
-  getErc20TokenBalance: () => {
-    return Promise.reject(tokensContextNotReadyMsg);
-  },
-  isContractAllowedToSpendToken: () => {
-    return Promise.reject(tokensContextNotReadyMsg);
-  },
-  approve: () => {
-    return Promise.reject(tokensContextNotReadyMsg);
-  },
+  addWrappedToken: () => Promise.reject(tokensContextNotReadyMsg),
+  getTokenFromAddress: () => Promise.reject(tokensContextNotReadyMsg),
+  getToken: () => Promise.reject(tokensContextNotReadyMsg),
+  getErc20TokenBalance: () => Promise.reject(tokensContextNotReadyMsg),
+  isContractAllowedToSpendToken: () => Promise.reject(tokensContextNotReadyMsg),
+  approve: () => Promise.reject(tokensContextNotReadyMsg),
 });
 
 const TokensProvider: FC<PropsWithChildren> = (props) => {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -43,10 +43,16 @@ export type AsyncTask<D, E, P = false> = P extends true
       | ReloadingAsyncTask<D>
       | FailedAsyncTask<E>;
 
-export function isAsyncTaskDataAvailable<D, E>(
-  task: AsyncTask<D, E>
-): task is SuccessfulAsyncTask<D> | ReloadingAsyncTask<D> {
-  return task.status === "successful" || task.status === "reloading";
+export function isAsyncTaskDataAvailable<D, E, P = false>(
+  task: AsyncTask<D, E, P>
+): task is P extends true
+  ? SuccessfulAsyncTask<D> | ReloadingAsyncTask<D> | LoadingMoreItemsAsyncTask<D>
+  : SuccessfulAsyncTask<D> | ReloadingAsyncTask<D> {
+  return (
+    task.status === "successful" ||
+    task.status === "reloading" ||
+    task.status === "loading-more-items"
+  );
 }
 
 export type Exact<T, U> = [T, U] extends [U, T] ? true : false;

--- a/src/views/activity/activity.styles.ts
+++ b/src/views/activity/activity.styles.ts
@@ -35,6 +35,7 @@ const useActivityStyles = createUseStyles((theme: Theme) => ({
     lineHeight: `${theme.spacing(1.75)}px`,
   },
   selectorBoxes: {
+    width: "100%",
     maxWidth: theme.maxWidth,
     display: "flex",
     margin: [theme.spacing(5), "auto", theme.spacing(2)],
@@ -71,13 +72,19 @@ const useActivityStyles = createUseStyles((theme: Theme) => ({
   },
   contentWrapper: {
     padding: [0, theme.spacing(2)],
+    display: "flex",
+    flexDirection: "column",
+    flex: 1,
   },
   emptyMessage: {
-    textAlign: "center",
-    lineHeight: "26px",
+    width: "100%",
     maxWidth: theme.maxWidth,
-    padding: 100,
-    margin: "auto",
+    alignSelf: "center",
+    textAlign: "center",
+    padding: [50, theme.spacing(2)],
+    [theme.breakpoints.upSm]: {
+      padding: 100,
+    },
   },
   bridgeCardwrapper: {
     "&:not(:last-child)": {

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -14,7 +14,7 @@ import { useErrorContext } from "src/contexts/error.context";
 import { useUIContext } from "src/contexts/ui.context";
 import { useTokensContext } from "src/contexts/tokens.context";
 import { parseError } from "src/adapters/error";
-import { isAxiosCancelRequestError } from "src/adapters/bridge-api";
+import { isCancelRequestError } from "src/adapters/bridge-api";
 import {
   AsyncTask,
   isAsyncTaskDataAvailable,
@@ -118,7 +118,7 @@ const Activity: FC = () => {
   const processFetchBridgesError = useCallback(
     (error: unknown) => {
       callIfMounted(() => {
-        if (!isAxiosCancelRequestError(error)) {
+        if (!isCancelRequestError(error)) {
           setBridgeList({
             status: "failed",
             error: undefined,

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -64,11 +64,7 @@ const Activity: FC = () => {
         bridge,
       })
         .then(() => {
-          if (
-            bridgeList.status === "successful" ||
-            bridgeList.status === "reloading" ||
-            bridgeList.status === "loading-more-items"
-          ) {
+          if (isAsyncTaskDataAvailable<Bridge[], undefined, true>(bridgeList)) {
             processFetchBridgesSuccess(bridgeList.data);
           }
           openSnackbar({

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -157,26 +157,24 @@ const Activity: FC = () => {
   };
 
   useEffect(() => {
+    // Initial load
     if (env && connectedProvider.status === "successful") {
       fetchBridgesAbortController.current = new AbortController();
-      const loadBridges = () => {
-        fetchBridges({
-          type: "load",
-          env,
-          ethereumAddress: connectedProvider.data.account,
-          limit: PAGE_SIZE,
-          offset: 0,
-          abortSignal: fetchBridgesAbortController.current.signal,
+      fetchBridges({
+        type: "load",
+        env,
+        ethereumAddress: connectedProvider.data.account,
+        limit: PAGE_SIZE,
+        offset: 0,
+        abortSignal: fetchBridgesAbortController.current.signal,
+      })
+        .then(({ bridges, total }) => {
+          callIfMounted(() => {
+            processFetchBridgesSuccess(bridges);
+            setTotal(total);
+          });
         })
-          .then(({ bridges, total }) => {
-            callIfMounted(() => {
-              processFetchBridgesSuccess(bridges);
-              setTotal(total);
-            });
-          })
-          .catch(processFetchBridgesError);
-      };
-      loadBridges();
+        .catch(processFetchBridgesError);
     }
     return () => {
       fetchBridgesAbortController.current.abort();
@@ -191,6 +189,7 @@ const Activity: FC = () => {
   ]);
 
   useEffect(() => {
+    // Polling
     if (
       env &&
       connectedProvider.status === "successful" &&

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -282,77 +282,75 @@ const Activity: FC = () => {
     return loader;
   }
 
-  return (() => {
-    switch (bridgeList.status) {
-      case "pending":
-      case "loading": {
-        return loader;
-      }
-      case "failed": {
-        return (
-          <div className={classes.contentWrapper}>
-            <Header title="Activity" backTo={{ routeKey: "home" }} />
-            <Tabs all={0} pending={0} />
-            <EmptyMessage />
-          </div>
-        );
-      }
-      case "successful":
-      case "loading-more-items":
-      case "reloading": {
-        const pendingBridges = bridgeList.data.filter((bridge) => bridge.status === "pending");
-        const filteredList = displayAll ? bridgeList.data : pendingBridges;
-
-        return (
-          <>
-            <div ref={headerBorderObserved}></div>
-            <div className={classes.stickyContent} ref={headerBorderTarget}>
-              <div className={classes.contentWrapper}>
-                <Header title="Activity" backTo={{ routeKey: "home" }} />
-                <Tabs all={bridgeList.data.length} pending={pendingBridges.length} />
-              </div>
-            </div>
-            <div className={classes.contentWrapper}>
-              {filteredList.length ? (
-                <InfiniteScroll
-                  isLoading={bridgeList.status === "loading-more-items"}
-                  onLoadNextPage={onLoadNextPage}
-                >
-                  {filteredList.map((bridge) =>
-                    bridge.status === "pending" ? (
-                      <div
-                        className={classes.bridgeCardwrapper}
-                        key={bridge.depositTxHash || bridge.claimTxHash}
-                      >
-                        <BridgeCard
-                          bridge={bridge}
-                          networkError={false}
-                          isFinaliseDisabled={true}
-                          showFiatAmount={env !== undefined && env.fiatExchangeRates.areEnabled}
-                        />
-                      </div>
-                    ) : (
-                      <div className={classes.bridgeCardwrapper} key={bridge.id}>
-                        <BridgeCard
-                          bridge={bridge}
-                          networkError={wrongNetworkBridges.includes(bridge.id)}
-                          isFinaliseDisabled={areBridgesDisabled}
-                          showFiatAmount={env !== undefined && env.fiatExchangeRates.areEnabled}
-                          onClaim={() => onClaim(bridge)}
-                        />
-                      </div>
-                    )
-                  )}
-                </InfiniteScroll>
-              ) : (
-                <EmptyMessage />
-              )}
-            </div>
-          </>
-        );
-      }
+  switch (bridgeList.status) {
+    case "pending":
+    case "loading": {
+      return loader;
     }
-  })();
+    case "failed": {
+      return (
+        <div className={classes.contentWrapper}>
+          <Header title="Activity" backTo={{ routeKey: "home" }} />
+          <Tabs all={0} pending={0} />
+          <EmptyMessage />
+        </div>
+      );
+    }
+    case "successful":
+    case "loading-more-items":
+    case "reloading": {
+      const pendingBridges = bridgeList.data.filter((bridge) => bridge.status === "pending");
+      const filteredList = displayAll ? bridgeList.data : pendingBridges;
+
+      return (
+        <>
+          <div ref={headerBorderObserved}></div>
+          <div className={classes.stickyContent} ref={headerBorderTarget}>
+            <div className={classes.contentWrapper}>
+              <Header title="Activity" backTo={{ routeKey: "home" }} />
+              <Tabs all={bridgeList.data.length} pending={pendingBridges.length} />
+            </div>
+          </div>
+          <div className={classes.contentWrapper}>
+            {filteredList.length ? (
+              <InfiniteScroll
+                isLoading={bridgeList.status === "loading-more-items"}
+                onLoadNextPage={onLoadNextPage}
+              >
+                {filteredList.map((bridge) =>
+                  bridge.status === "pending" ? (
+                    <div
+                      className={classes.bridgeCardwrapper}
+                      key={bridge.depositTxHash || bridge.claimTxHash}
+                    >
+                      <BridgeCard
+                        bridge={bridge}
+                        networkError={false}
+                        isFinaliseDisabled={true}
+                        showFiatAmount={env !== undefined && env.fiatExchangeRates.areEnabled}
+                      />
+                    </div>
+                  ) : (
+                    <div className={classes.bridgeCardwrapper} key={bridge.id}>
+                      <BridgeCard
+                        bridge={bridge}
+                        networkError={wrongNetworkBridges.includes(bridge.id)}
+                        isFinaliseDisabled={areBridgesDisabled}
+                        showFiatAmount={env !== undefined && env.fiatExchangeRates.areEnabled}
+                        onClaim={() => onClaim(bridge)}
+                      />
+                    </div>
+                  )
+                )}
+              </InfiniteScroll>
+            ) : (
+              <EmptyMessage />
+            )}
+          </div>
+        </>
+      );
+    }
+  }
 };
 
 export default Activity;

--- a/src/views/activity/activity.view.tsx
+++ b/src/views/activity/activity.view.tsx
@@ -12,6 +12,7 @@ import { useProvidersContext } from "src/contexts/providers.context";
 import { useEnvContext } from "src/contexts/env.context";
 import { useErrorContext } from "src/contexts/error.context";
 import { useUIContext } from "src/contexts/ui.context";
+import { useTokensContext } from "src/contexts/tokens.context";
 import { parseError } from "src/adapters/error";
 import { isAxiosCancelRequestError } from "src/adapters/bridge-api";
 import {
@@ -31,6 +32,7 @@ const Activity: FC = () => {
   const { connectedProvider } = useProvidersContext();
   const { notifyError } = useErrorContext();
   const { openSnackbar } = useUIContext();
+  const { tokens } = useTokensContext();
   const [bridgeList, setBridgeList] = useState<AsyncTask<Bridge[], undefined, true>>({
     status: "pending",
   });
@@ -158,7 +160,7 @@ const Activity: FC = () => {
 
   useEffect(() => {
     // Initial load
-    if (env && connectedProvider.status === "successful") {
+    if (env && connectedProvider.status === "successful" && tokens) {
       fetchBridgesAbortController.current = new AbortController();
       fetchBridges({
         type: "load",
@@ -182,6 +184,7 @@ const Activity: FC = () => {
   }, [
     connectedProvider,
     env,
+    tokens,
     callIfMounted,
     fetchBridges,
     processFetchBridgesError,
@@ -267,17 +270,23 @@ const Activity: FC = () => {
     </div>
   );
 
+  const loader = (
+    <div className={classes.contentWrapper}>
+      <Header title="Activity" backTo={{ routeKey: "home" }} />
+      <Tabs all={0} pending={0} />
+      <PageLoader />
+    </div>
+  );
+
+  if (!tokens) {
+    return loader;
+  }
+
   return (() => {
     switch (bridgeList.status) {
       case "pending":
       case "loading": {
-        return (
-          <div className={classes.contentWrapper}>
-            <Header title="Activity" backTo={{ routeKey: "home" }} />
-            <Tabs all={0} pending={0} />
-            <PageLoader />
-          </div>
-        );
+        return loader;
       }
       case "failed": {
         return (

--- a/src/views/bridge-details/bridge-details.view.tsx
+++ b/src/views/bridge-details/bridge-details.view.tsx
@@ -32,7 +32,7 @@ import routes from "src/routes";
 import { FIAT_DISPLAY_PRECISION, getEtherToken } from "src/constants";
 import useCallIfMounted from "src/hooks/use-call-if-mounted";
 import { useTokensContext } from "src/contexts/tokens.context";
-import { isAxiosCancelRequestError } from "src/adapters/bridge-api";
+import { isCancelRequestError } from "src/adapters/bridge-api";
 import { Bridge } from "src/domain";
 
 interface Fees {
@@ -151,7 +151,7 @@ const BridgeDetails: FC = () => {
             });
           })
           .catch((error) => {
-            if (!isAxiosCancelRequestError(error)) {
+            if (!isCancelRequestError(error)) {
               callIfMounted(() => {
                 notifyError(error);
                 setBridge({

--- a/src/views/bridge-details/bridge-details.view.tsx
+++ b/src/views/bridge-details/bridge-details.view.tsx
@@ -124,7 +124,7 @@ const BridgeDetails: FC = () => {
   }, [connectedProvider, bridge]);
 
   useEffect(() => {
-    if (env && connectedProvider.status === "successful") {
+    if (env && connectedProvider.status === "successful" && tokens) {
       const parsedBridgeId = deserializeBridgeId(bridgeId);
       if (parsedBridgeId.success) {
         const { depositCount, networkId } = parsedBridgeId.data;
@@ -164,7 +164,7 @@ const BridgeDetails: FC = () => {
         });
       }
     }
-  }, [env, bridgeId, connectedProvider, notifyError, getBridge, callIfMounted, navigate]);
+  }, [env, tokens, bridgeId, connectedProvider, notifyError, getBridge, callIfMounted, navigate]);
 
   useEffect(() => {
     if (bridge.status === "successful") {

--- a/src/views/bridge-details/bridge-details.view.tsx
+++ b/src/views/bridge-details/bridge-details.view.tsx
@@ -151,15 +151,15 @@ const BridgeDetails: FC = () => {
             });
           })
           .catch((error) => {
-            if (!isCancelRequestError(error)) {
-              callIfMounted(() => {
+            callIfMounted(() => {
+              if (!isCancelRequestError(error)) {
                 notifyError(error);
                 setBridge({
                   status: "failed",
                   error: "Bridge not found",
                 });
-              });
-            }
+              }
+            });
           });
       } else {
         callIfMounted(() => {

--- a/src/views/bridge-details/bridge-details.view.tsx
+++ b/src/views/bridge-details/bridge-details.view.tsx
@@ -214,11 +214,11 @@ const BridgeDetails: FC = () => {
   }, [env, bridge, getTokenPrice, callIfMounted]);
 
   useEffect(() => {
-    if (env !== undefined && env.fiatExchangeRates.areEnabled && bridge.status === "successful") {
+    if (tokens && env?.fiatExchangeRates.areEnabled && bridge.status === "successful") {
       const { from } = bridge.data;
 
       // fiat fees
-      const token = tokens?.find((t) => t.symbol === "WETH");
+      const token = tokens.find((t) => t.symbol === "WETH");
       if (token) {
         getTokenPrice({ token, chain: from })
           .then((tokenPrice) => {

--- a/src/views/bridge-details/bridge-details.view.tsx
+++ b/src/views/bridge-details/bridge-details.view.tsx
@@ -74,7 +74,7 @@ const BridgeDetails: FC = () => {
   const navigate = useNavigate();
   const env = useEnvContext();
   const { notifyError } = useErrorContext();
-  const { claim, getBridge } = useBridgeContext();
+  const { claim, fetchBridge } = useBridgeContext();
   const { tokens } = useTokensContext();
   const { connectedProvider } = useProvidersContext();
   const { getTokenPrice } = usePriceOracleContext();
@@ -92,7 +92,7 @@ const BridgeDetails: FC = () => {
     status: bridge.status === "successful" ? bridge.data.status : undefined,
   });
 
-  const getBridgeAbortController = useRef<AbortController>(new AbortController());
+  const fetchBridgeAbortController = useRef<AbortController>(new AbortController());
 
   const onClaim = () => {
     if (bridge.status === "successful" && bridge.data.status === "on-hold") {
@@ -128,15 +128,15 @@ const BridgeDetails: FC = () => {
 
   useEffect(() => {
     if (env && connectedProvider.status === "successful" && tokens) {
-      getBridgeAbortController.current = new AbortController();
+      fetchBridgeAbortController.current = new AbortController();
       const parsedBridgeId = deserializeBridgeId(bridgeId);
       if (parsedBridgeId.success) {
         const { depositCount, networkId } = parsedBridgeId.data;
-        void getBridge({
+        void fetchBridge({
           env,
           depositCount,
           networkId,
-          abortSignal: getBridgeAbortController.current.signal,
+          abortSignal: fetchBridgeAbortController.current.signal,
         })
           .then((bridge) => {
             callIfMounted(() => {
@@ -171,10 +171,10 @@ const BridgeDetails: FC = () => {
         });
       }
       return () => {
-        getBridgeAbortController.current.abort();
+        fetchBridgeAbortController.current.abort();
       };
     }
-  }, [env, tokens, bridgeId, connectedProvider, notifyError, getBridge, callIfMounted, navigate]);
+  }, [env, tokens, bridgeId, connectedProvider, notifyError, fetchBridge, callIfMounted, navigate]);
 
   useEffect(() => {
     if (bridge.status === "successful") {

--- a/src/views/home/components/bridge-form/bridge-form.view.tsx
+++ b/src/views/home/components/bridge-form/bridge-form.view.tsx
@@ -285,7 +285,7 @@ const BridgeForm: FC<BridgeFormProps> = ({
       setAmount(undefined);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connectedProvider]);
+  }, [connectedProvider, env]);
 
   useEffect(() => {
     // Load default form values


### PR DESCRIPTION
Closes #219

### What does this PR does?

The Activity screen of the Bridge implements a polling to always show the fresh status of the bridges to the user.

The app uses the Axios' [cancel token API](https://axios-http.com/docs/cancellation) to abort an in-progress polling request when the user requests a new page. After the new page is retrieved the polling is resumed.

Currently, the `CanceledError` of the cancel token API is not properly managed, and therefore when a polling request is canceled the UI shows the report error bar with the error:

```An unknown error has occurred: {"message":"canceled","name":"CanceledError","code":"ERR_CANCELED","status":null}```

![image](https://user-images.githubusercontent.com/15896177/197169883-c64764c1-a13f-408d-934e-335200922c8c.png)

Considering that the cancel token API is currently deprecated in favor of the [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) to cancel requests this PR tackles the following:

* Replacing the cancel token API with the AbortController.
* Using the Axios util `isCancel` to easily spot and ignore cancelation errors.
* Prevent extra requests to the API when the Activity page is initially loaded.
* Prevent extra requests to the API when the Bridge Details page is initially loaded.