### PR TITLE
Remove unnecessary useRef in Bridge Details screen

### DIFF
--- a/src/views/bridge-details/bridge-details.view.tsx
+++ b/src/views/bridge-details/bridge-details.view.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState, useRef } from "react";
+import { FC, useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { BigNumber } from "ethers";
 
@@ -92,8 +92,6 @@ const BridgeDetails: FC = () => {
     status: bridge.status === "successful" ? bridge.data.status : undefined,
   });
 
-  const fetchBridgeAbortController = useRef<AbortController>(new AbortController());
-
   const onClaim = () => {
     if (bridge.status === "successful" && bridge.data.status === "on-hold") {
       setIsFinaliseButtonDisabled(true);
@@ -128,7 +126,7 @@ const BridgeDetails: FC = () => {
 
   useEffect(() => {
     if (env && connectedProvider.status === "successful" && tokens) {
-      fetchBridgeAbortController.current = new AbortController();
+      const abortController = new AbortController();
       const parsedBridgeId = deserializeBridgeId(bridgeId);
       if (parsedBridgeId.success) {
         const { depositCount, networkId } = parsedBridgeId.data;
@@ -136,7 +134,7 @@ const BridgeDetails: FC = () => {
           env,
           depositCount,
           networkId,
-          abortSignal: fetchBridgeAbortController.current.signal,
+          abortSignal: abortController.signal,
         })
           .then((bridge) => {
             callIfMounted(() => {
@@ -171,7 +169,7 @@ const BridgeDetails: FC = () => {
         });
       }
       return () => {
-        fetchBridgeAbortController.current.abort();
+        abortController.abort();
       };
     }
   }, [env, tokens, bridgeId, connectedProvider, notifyError, fetchBridge, callIfMounted, navigate]);


### PR DESCRIPTION
### What does this PR does?

This PR removes an unnecessary `useRef` used for the AbortController of the Bridge Details screen, introduced in [this PR](https://github.com/0xPolygonHermez/zkevm-bridge-ui/pull/222/files#diff-aa2c650daed1608923dd5fe33bacd712d6d4245c54c7820b2a324056f02972a6R95).