### PR TITLE
Redirect from network-error to home when the nodes are operative

### DIFF
--- a/src/views/network-error/network-error.view.tsx
+++ b/src/views/network-error/network-error.view.tsx
@@ -1,8 +1,9 @@
-import { FC } from "react";
+import { FC, useEffect } from "react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
 
 import { providerError } from "src/adapters/error";
 import { ReactComponent as PolygonZkEVMLogo } from "src/assets/polygon-zkevm-logo.svg";
+import { useEnvContext } from "src/contexts/env.context";
 import { ProviderError } from "src/domain";
 import { routes } from "src/routes";
 import useNetworkErrorStyles from "src/views/network-error/network-error.styles";
@@ -12,6 +13,13 @@ const NetworkError: FC = () => {
   const classes = useNetworkErrorStyles();
   const navigate = useNavigate();
   const { state } = useLocation();
+  const env = useEnvContext();
+
+  useEffect(() => {
+    if (env) {
+      navigate(routes.home.path);
+    }
+  }, [env, navigate]);
 
   const parsedProviderError = providerError.safeParse(state);
 


### PR DESCRIPTION
Closes #245

### What does this PR does?

When a node is down, the "Network Error" screen is displayed. With this PR, once at the "Network Error" screen, if the network is available again and the user refreshes the page, they are redirected home without needing to click the "Try Again" button like before.

### How to test?

* Set an incorrect URL for a node in the env.
* Load the app.
* Once on the network error page, fix the URL in the env.

The auto-reload should bring you back home.