### PR TITLE
Rename zkevm_batchNumberOfL2Block custom RPC endpoint

### DIFF
--- a/src/adapters/ethereum.ts
+++ b/src/adapters/ethereum.ts
@@ -33,7 +33,7 @@ const getBatchNumberOfL2Block = async (
   provider: JsonRpcProvider,
   blockNumber: number
 ): Promise<number> => {
-  const batchNumberOfL2Block: unknown = await provider.send("zkevm_batchNumberOfL2Block", [
+  const batchNumberOfL2Block: unknown = await provider.send("zkevm_batchNumberByBlockNumber", [
     blockNumber,
   ]);
   return z.number().parse(batchNumberOfL2Block);


### PR DESCRIPTION
### What does this PR does?

This PR updates the name of the `zkevm_batchNumberOfL2Block` method to the newest one according to the [docs](https://github.com/0xPolygonHermez/zkevm-node/blob/develop/jsonrpc/endpoints_zkevm.openrpc.json). This PR shouldn't be merged until the `v0.0.2` of the `zkemv-node` has been released and deployed.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [x] Update documentation (if needed)
