### PR TITLE
Cache getToken requests and fix `zkevm_batchNumberOfL2Block` requests

### DIFF
--- a/src/contexts/tokens.context.tsx
+++ b/src/contexts/tokens.context.tsx
@@ -9,6 +9,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -91,7 +92,7 @@ const TokensProvider: FC<PropsWithChildren> = (props) => {
   const { notifyError } = useErrorContext();
   const { changeNetwork, connectedProvider } = useProvidersContext();
   const [tokens, setTokens] = useState<Token[]>();
-  const [fetchedTokens, setFetchedTokens] = useState<Token[]>([]);
+  const fetchedTokens = useRef<Token[]>([]);
 
   /**
    * Provided a token, its native chain and any other chain, computes the address of the wrapped token on the other chain
@@ -247,7 +248,7 @@ const TokensProvider: FC<PropsWithChildren> = (props) => {
       const token = [
         ...getCustomTokens(),
         ...(tokens || [getEtherToken(chain)]),
-        ...fetchedTokens,
+        ...fetchedTokens.current,
       ].find(
         (token) =>
           (token.address === tokenOriginAddress && token.chainId === chain.chainId) ||
@@ -261,7 +262,7 @@ const TokensProvider: FC<PropsWithChildren> = (props) => {
       } else {
         return getTokenFromAddress({ address: tokenOriginAddress, chain })
           .then((token) => {
-            setFetchedTokens((currentFetchedTokens) => [...currentFetchedTokens, token]);
+            fetchedTokens.current = [...fetchedTokens.current, token];
             return token;
           })
           .catch(() => {
@@ -271,7 +272,7 @@ const TokensProvider: FC<PropsWithChildren> = (props) => {
           });
       }
     },
-    [tokens, fetchedTokens, getTokenFromAddress]
+    [tokens, getTokenFromAddress]
   );
 
   const getErc20TokenBalance = useCallback(

--- a/src/views/activity/components/bridge-card/bridge-card.view.tsx
+++ b/src/views/activity/components/bridge-card/bridge-card.view.tsx
@@ -43,14 +43,17 @@ export const BridgeCard: FC<BridgeCardProps> = ({
     status: "pending",
   });
 
+  const [blockNumber, fromKey] =
+    bridge.status !== "pending" ? [bridge.blockNumber, bridge.from.key] : [undefined, undefined];
+
   useEffect(() => {
-    if (status !== "pending" && bridge.from.key === "polygon-zkevm") {
+    if (status === "initiated" && fromKey === "polygon-zkevm") {
       setBatchNumberOfL2Block((currentBatchNumberOfL2Block) =>
         isAsyncTaskDataAvailable(currentBatchNumberOfL2Block)
           ? { data: currentBatchNumberOfL2Block.data, status: "reloading" }
           : { status: "loading" }
       );
-      getBatchNumberOfL2Block(env.chains[1].provider, bridge.blockNumber)
+      getBatchNumberOfL2Block(env.chains[1].provider, blockNumber)
         .then((newBatchNumberOfL2Block) => {
           setBatchNumberOfL2Block({
             data: BigNumber.from(newBatchNumberOfL2Block),
@@ -64,7 +67,7 @@ export const BridgeCard: FC<BridgeCardProps> = ({
           });
         });
     }
-  }, [bridge, env, status]);
+  }, [blockNumber, env, fromKey, status]);
 
   const onClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();


### PR DESCRIPTION
Closes #252 

### What does this PR does?

The Bridge domain entity has a token property that is used by several views, such as the activity view. When the token of a bridge can't be found either in the "standard" or "custom" tokens, it's requested to the network. 

Since these token requests were not cached and the user might have several bridges with the same token, multiple identical calls were made to the RPC. In some scenarios, this caused a flood of requests to the RPC in the activity view.

This PR implements a cache in the token context so all the tokens that have already been requested to the network are not requested a second time.

Apart from this, it also fixes 2 bugs that were causing the method `zkevm_batchNumberOfL2Block` to be called multiple extra times.
* The use effect is now executed only for INITIATED bridges.
* The use effect is now executed only once per bridge.