### PR TITLE
Update SC ABIs

### DIFF
--- a/abis/bridge.json
+++ b/abis/bridge.json
@@ -1,5 +1,85 @@
 [
   {
+    "inputs": [],
+    "name": "AlreadyClaimed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AmountDoesNotMatchMsgValue",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DestinationNetworkInvalid",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EtherTransferFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GlobalExitRootInvalid",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidSmtProof",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MerkleTreeFull",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MessageFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MsgValueNotZero",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotValidAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotValidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotValidSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotValidSpender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyEmergencyState",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyNotEmergencyState",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyPolygonZkEVM",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -136,49 +216,16 @@
         "internalType": "address",
         "name": "wrappedTokenAddress",
         "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "metadata",
+        "type": "bytes"
       }
     ],
     "name": "NewWrappedToken",
     "type": "event"
-  },
-  {
-    "inputs": [],
-    "name": "LEAF_TYPE_ASSET",
-    "outputs": [
-      {
-        "internalType": "uint8",
-        "name": "",
-        "type": "uint8"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "LEAF_TYPE_MESSAGE",
-    "outputs": [
-      {
-        "internalType": "uint8",
-        "name": "",
-        "type": "uint8"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "MAINNET_NETWORK_ID",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
   },
   {
     "inputs": [],
@@ -246,9 +293,9 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32[]",
+        "internalType": "bytes32[32]",
         "name": "smtProof",
-        "type": "bytes32[]"
+        "type": "bytes32[32]"
       },
       {
         "internalType": "uint32",
@@ -304,9 +351,9 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32[]",
+        "internalType": "bytes32[32]",
         "name": "smtProof",
-        "type": "bytes32[]"
+        "type": "bytes32[32]"
       },
       {
         "internalType": "uint32",
@@ -489,7 +536,7 @@
     "name": "globalExitRootManager",
     "outputs": [
       {
-        "internalType": "contract IPolygonZkEVMGlobalExitRoot",
+        "internalType": "contract IBasePolygonZkEVMGlobalExitRoot",
         "name": "",
         "type": "address"
       }
@@ -505,7 +552,7 @@
         "type": "uint32"
       },
       {
-        "internalType": "contract IPolygonZkEVMGlobalExitRoot",
+        "internalType": "contract IBasePolygonZkEVMGlobalExitRoot",
         "name": "_globalExitRootManager",
         "type": "address"
       },
@@ -644,14 +691,14 @@
         "type": "bytes32"
       },
       {
-        "internalType": "bytes32[]",
+        "internalType": "bytes32[32]",
         "name": "smtProof",
-        "type": "bytes32[]"
+        "type": "bytes32[32]"
       },
       {
-        "internalType": "uint64",
+        "internalType": "uint32",
         "name": "index",
-        "type": "uint64"
+        "type": "uint32"
       },
       {
         "internalType": "bytes32",

--- a/abis/bridge.json
+++ b/abis/bridge.json
@@ -142,38 +142,6 @@
     "type": "event"
   },
   {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "OwnershipTransferred",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "newClaimTimeout",
-        "type": "uint256"
-      }
-    ],
-    "name": "SetClaimTimeout",
-    "type": "event"
-  },
-  {
     "inputs": [],
     "name": "LEAF_TYPE_ASSET",
     "outputs": [
@@ -399,20 +367,7 @@
         "type": "uint256"
       }
     ],
-    "name": "claimNullifier",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "claimTimeout",
+    "name": "claimedBitMap",
     "outputs": [
       {
         "internalType": "uint256",
@@ -534,7 +489,7 @@
     "name": "globalExitRootManager",
     "outputs": [
       {
-        "internalType": "contract IGlobalExitRootManager",
+        "internalType": "contract IPolygonZkEVMGlobalExitRoot",
         "name": "",
         "type": "address"
       }
@@ -550,19 +505,14 @@
         "type": "uint32"
       },
       {
-        "internalType": "contract IGlobalExitRootManager",
+        "internalType": "contract IPolygonZkEVMGlobalExitRoot",
         "name": "_globalExitRootManager",
         "type": "address"
       },
       {
         "internalType": "address",
-        "name": "_poeAddress",
+        "name": "_polygonZkEVMaddress",
         "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_claimTimeout",
-        "type": "uint256"
       }
     ],
     "name": "initialize",
@@ -571,8 +521,14 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "isEmergencyState",
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "isClaimed",
     "outputs": [
       {
         "internalType": "bool",
@@ -585,12 +541,12 @@
   },
   {
     "inputs": [],
-    "name": "maxEtherBridge",
+    "name": "isEmergencyState",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "bool",
         "name": "",
-        "type": "uint256"
+        "type": "bool"
       }
     ],
     "stateMutability": "view",
@@ -611,20 +567,7 @@
   },
   {
     "inputs": [],
-    "name": "owner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "poeAddress",
+    "name": "polygonZkEVMaddress",
     "outputs": [
       {
         "internalType": "address",
@@ -675,52 +618,6 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "renounceOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "newClaimTimeout",
-        "type": "uint256"
-      }
-    ],
-    "name": "setClaimTimeout",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_maxEtherBridge",
-        "type": "uint256"
-      }
-    ],
-    "name": "setMaxEtherBridge",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint32",
-        "name": "_networkID",
-        "type": "uint32"
-      }
-    ],
-    "name": "setNetworkID",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -737,19 +634,6 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "transferOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/abis/proof-of-efficiency.json
+++ b/abis/proof-of-efficiency.json
@@ -1,6 +1,31 @@
 [
   {
     "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "numBatch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "stateRoot",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "pendingStateNum",
+        "type": "uint64"
+      }
+    ],
+    "name": "ConsolidatePendingState",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
     "inputs": [],
     "name": "EmergencyStateActivated",
     "type": "event"
@@ -60,6 +85,31 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "uint64",
+        "name": "numBatch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "stateRoot",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "aggregator",
+        "type": "address"
+      }
+    ],
+    "name": "OverridePendingState",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "address",
         "name": "previousOwner",
         "type": "address"
@@ -90,7 +140,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "ProveNonDeterministicState",
+    "name": "ProveNonDeterministicPendingState",
     "type": "event"
   },
   {
@@ -124,6 +174,19 @@
     "inputs": [
       {
         "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "SetAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "bool",
         "name": "newForceBatchAllowed",
         "type": "bool"
@@ -137,12 +200,51 @@
     "inputs": [
       {
         "indexed": false,
+        "internalType": "uint16",
+        "name": "newMultiplierBatchFee",
+        "type": "uint16"
+      }
+    ],
+    "name": "SetMultiplierBatchFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "newPendingStateTimeout",
+        "type": "uint64"
+      }
+    ],
+    "name": "SetPendingStateTimeout",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "address",
-        "name": "newSecurityCouncil",
+        "name": "newTrustedAggregator",
         "type": "address"
       }
     ],
-    "name": "SetSecurityCouncil",
+    "name": "SetTrustedAggregator",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "newTrustedAggregatorTimeout",
+        "type": "uint64"
+      }
+    ],
+    "name": "SetTrustedAggregatorTimeout",
     "type": "event"
   },
   {
@@ -169,6 +271,44 @@
       }
     ],
     "name": "SetTrustedSequencerURL",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "newVeryBatchTimeTarget",
+        "type": "uint64"
+      }
+    ],
+    "name": "SetVeryBatchTimeTarget",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "numBatch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "stateRoot",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "aggregator",
+        "type": "address"
+      }
+    ],
+    "name": "TrustedVerifyBatches",
     "type": "event"
   },
   {
@@ -211,7 +351,20 @@
   },
   {
     "inputs": [],
-    "name": "MAX_BATCH_LENGTH",
+    "name": "HALT_AGGREGATION_TIMEOUT",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_BATCH_MULTIPLIER",
     "outputs": [
       {
         "internalType": "uint256",
@@ -224,7 +377,7 @@
   },
   {
     "inputs": [],
-    "name": "TRUSTED_SEQUENCER_FEE",
+    "name": "MAX_TRANSACTIONS_BYTE_LENGTH",
     "outputs": [
       {
         "internalType": "uint256",
@@ -237,9 +390,54 @@
   },
   {
     "inputs": [],
+    "name": "MAX_VERIFY_BATCHES",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "sequencedBatchNum",
+        "type": "uint64"
+      }
+    ],
     "name": "activateEmergencyState",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "admin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "batchFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -266,61 +464,9 @@
     "name": "bridgeAddress",
     "outputs": [
       {
-        "internalType": "contract IBridge",
+        "internalType": "contract IPolygonZkEVMBridge",
         "name": "",
         "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "currentAccInputHash",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "bytes",
-        "name": "transactions",
-        "type": "bytes"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "globalExitRoot",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint64",
-        "name": "timestamp",
-        "type": "uint64"
-      },
-      {
-        "internalType": "address",
-        "name": "sequencerAddress",
-        "type": "address"
-      }
-    ],
-    "name": "calculateAccInputHash",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "calculateForceProverFee",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -350,6 +496,19 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "pendingStateNum",
+        "type": "uint64"
+      }
+    ],
+    "name": "consolidatePendingState",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -410,6 +569,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "getCurrentBatchFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint64",
@@ -424,6 +596,11 @@
       {
         "internalType": "bytes32",
         "name": "newLocalExitRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "oldStateRoot",
         "type": "bytes32"
       },
       {
@@ -444,34 +621,13 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "_lastVerifiedBatch",
-        "type": "uint64"
-      },
-      {
-        "internalType": "uint64",
-        "name": "newVerifiedBatch",
-        "type": "uint64"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "newLocalExitRoot",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "newStateRoot",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getNextSnarkInput",
+    "inputs": [],
+    "name": "getLastVerifiedBatch",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint64",
         "name": "",
-        "type": "uint256"
+        "type": "uint64"
       }
     ],
     "stateMutability": "view",
@@ -482,7 +638,7 @@
     "name": "globalExitRootManager",
     "outputs": [
       {
-        "internalType": "contract IGlobalExitRootManager",
+        "internalType": "contract IPolygonZkEVMGlobalExitRoot",
         "name": "",
         "type": "address"
       }
@@ -493,7 +649,7 @@
   {
     "inputs": [
       {
-        "internalType": "contract IGlobalExitRootManager",
+        "internalType": "contract IPolygonZkEVMGlobalExitRoot",
         "name": "_globalExitRootManager",
         "type": "address"
       },
@@ -508,19 +664,56 @@
         "type": "address"
       },
       {
-        "internalType": "bytes32",
-        "name": "genesisRoot",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "_trustedSequencer",
+        "internalType": "contract IPolygonZkEVMBridge",
+        "name": "_bridgeAddress",
         "type": "address"
       },
       {
-        "internalType": "bool",
-        "name": "_forceBatchAllowed",
-        "type": "bool"
+        "components": [
+          {
+            "internalType": "address",
+            "name": "admin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "chainID",
+            "type": "uint64"
+          },
+          {
+            "internalType": "address",
+            "name": "trustedSequencer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "pendingStateTimeout",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "forceBatchAllowed",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "trustedAggregator",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "trustedAggregatorTimeout",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct PolygonZkEVM.InitializePackedParameters",
+        "name": "initializePackedParameters",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "genesisRoot",
+        "type": "bytes32"
       },
       {
         "internalType": "string",
@@ -528,24 +721,9 @@
         "type": "string"
       },
       {
-        "internalType": "uint64",
-        "name": "_chainID",
-        "type": "uint64"
-      },
-      {
         "internalType": "string",
         "name": "_networkName",
         "type": "string"
-      },
-      {
-        "internalType": "contract IBridge",
-        "name": "_bridgeAddress",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_securityCouncil",
-        "type": "address"
       }
     ],
     "name": "initialize",
@@ -556,6 +734,25 @@
   {
     "inputs": [],
     "name": "isEmergencyState",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "pendingStateNum",
+        "type": "uint64"
+      }
+    ],
+    "name": "isPendingStateConsolidable",
     "outputs": [
       {
         "internalType": "bool",
@@ -607,6 +804,32 @@
   },
   {
     "inputs": [],
+    "name": "lastPendingState",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastPendingStateConsolidated",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "lastTimestamp",
     "outputs": [
       {
@@ -646,6 +869,19 @@
   },
   {
     "inputs": [],
+    "name": "multiplierBatchFee",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "networkName",
     "outputs": [
       {
@@ -658,20 +894,17 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "owner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "initPendingStateNum",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "finalPendingStateNum",
+        "type": "uint64"
+      },
       {
         "internalType": "uint64",
         "name": "initNumBatch",
@@ -708,7 +941,120 @@
         "type": "uint256[2]"
       }
     ],
-    "name": "proveNonDeterministicState",
+    "name": "overridePendingState",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingStateTimeout",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "pendingStateTransitions",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "timestamp",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "lastVerifiedBatch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "exitRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "stateRoot",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "initPendingStateNum",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "finalPendingStateNum",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "initNumBatch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "finalNewBatch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "newLocalExitRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "newStateRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[2]",
+        "name": "proofA",
+        "type": "uint256[2]"
+      },
+      {
+        "internalType": "uint256[2][2]",
+        "name": "proofB",
+        "type": "uint256[2][2]"
+      },
+      {
+        "internalType": "uint256[2]",
+        "name": "proofC",
+        "type": "uint256[2]"
+      }
+    ],
+    "name": "proveNonDeterministicPendingState",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -726,19 +1072,6 @@
     "outputs": [
       {
         "internalType": "contract IVerifierRollup",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "securityCouncil",
-    "outputs": [
-      {
-        "internalType": "address",
         "name": "",
         "type": "address"
       }
@@ -771,7 +1104,7 @@
             "type": "uint64"
           }
         ],
-        "internalType": "struct ProofOfEfficiency.BatchData[]",
+        "internalType": "struct PolygonZkEVM.BatchData[]",
         "name": "batches",
         "type": "tuple[]"
       }
@@ -801,7 +1134,7 @@
             "type": "uint64"
           }
         ],
-        "internalType": "struct ProofOfEfficiency.ForceBatchData[]",
+        "internalType": "struct PolygonZkEVM.ForcedBatchData[]",
         "name": "batches",
         "type": "tuple[]"
       }
@@ -823,11 +1156,34 @@
     "outputs": [
       {
         "internalType": "bytes32",
-        "name": "",
+        "name": "accInputHash",
         "type": "bytes32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "sequencedTimestamp",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "previousLastBatchSequenced",
+        "type": "uint64"
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "setAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -846,12 +1202,25 @@
   {
     "inputs": [
       {
-        "internalType": "string",
-        "name": "_networkName",
-        "type": "string"
+        "internalType": "uint16",
+        "name": "newMultiplierBatchFee",
+        "type": "uint16"
       }
     ],
-    "name": "setNetworkName",
+    "name": "setMultiplierBatchFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "newPendingStateTimeout",
+        "type": "uint64"
+      }
+    ],
+    "name": "setPendingStateTimeout",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -860,11 +1229,11 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "newSecurityCouncil",
+        "name": "newTrustedAggregator",
         "type": "address"
       }
     ],
-    "name": "setSecurityCouncil",
+    "name": "setTrustedAggregator",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -873,47 +1242,11 @@
     "inputs": [
       {
         "internalType": "uint64",
-        "name": "_numBatch",
+        "name": "newTrustedAggregatorTimeout",
         "type": "uint64"
       }
     ],
-    "name": "setSequencedBatch",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "batchNum",
-        "type": "uint64"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "accInputData",
-        "type": "bytes32"
-      }
-    ],
-    "name": "setSequencedBatches",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "newStateRoot",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint64",
-        "name": "batchNum",
-        "type": "uint64"
-      }
-    ],
-    "name": "setStateRoot",
+    "name": "setTrustedAggregatorTimeout",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -948,24 +1281,11 @@
     "inputs": [
       {
         "internalType": "uint64",
-        "name": "_numBatch",
+        "name": "newVeryBatchTimeTarget",
         "type": "uint64"
       }
     ],
-    "name": "setVerifiedBatch",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "contract IVerifierRollup",
-        "name": "_rollupVerifier",
-        "type": "address"
-      }
-    ],
-    "name": "setVerifier",
+    "name": "setVeryBatchTimeTarget",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -981,6 +1301,32 @@
     "name": "transferOwnership",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "trustedAggregator",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "trustedAggregatorTimeout",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -1011,6 +1357,59 @@
   },
   {
     "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "pendingStateNum",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "initNumBatch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "finalNewBatch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "newLocalExitRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "newStateRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[2]",
+        "name": "proofA",
+        "type": "uint256[2]"
+      },
+      {
+        "internalType": "uint256[2][2]",
+        "name": "proofB",
+        "type": "uint256[2][2]"
+      },
+      {
+        "internalType": "uint256[2]",
+        "name": "proofC",
+        "type": "uint256[2]"
+      }
+    ],
+    "name": "trustedVerifyBatches",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "pendingStateNum",
+        "type": "uint64"
+      },
       {
         "internalType": "uint64",
         "name": "initNumBatch",
@@ -1053,46 +1452,16 @@
     "type": "function"
   },
   {
-    "inputs": [
+    "inputs": [],
+    "name": "veryBatchTimeTarget",
+    "outputs": [
       {
         "internalType": "uint64",
-        "name": "_lastVerifiedBatch",
+        "name": "",
         "type": "uint64"
-      },
-      {
-        "internalType": "uint64",
-        "name": "newVerifiedBatch",
-        "type": "uint64"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "newLocalExitRoot",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "newStateRoot",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint256[2]",
-        "name": "proofA",
-        "type": "uint256[2]"
-      },
-      {
-        "internalType": "uint256[2][2]",
-        "name": "proofB",
-        "type": "uint256[2][2]"
-      },
-      {
-        "internalType": "uint256[2]",
-        "name": "proofC",
-        "type": "uint256[2]"
       }
     ],
-    "name": "verifyBatchesMock",
-    "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/abis/proof-of-efficiency.json
+++ b/abis/proof-of-efficiency.json
@@ -1,5 +1,249 @@
 [
   {
+    "inputs": [
+      {
+        "internalType": "contract IPolygonZkEVMGlobalExitRoot",
+        "name": "_globalExitRootManager",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20Upgradeable",
+        "name": "_matic",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IVerifierRollup",
+        "name": "_rollupVerifier",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IPolygonZkEVMBridge",
+        "name": "_bridgeAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_chainID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_forkID",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "BatchAlreadyVerified",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BatchNotSequencedOrNotSequenceEnd",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExceedMaxVerifyBatches",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FinalNumBatchBelowLastVerifiedBatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FinalNumBatchDoesNotMatchPendingState",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FinalPendingStateNumInvalid",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ForceBatchTimeoutNotExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ForceBatchesOverflow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ForcedDataDoesNotMatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GlobalExitRootNotExist",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "HaltTimeoutNotExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InitNumBatchAboveLastVerifiedBatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InitNumBatchDoesNotMatchPendingState",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidProof",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidRangeBatchTimeTarget",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidRangeMultiplierBatchFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NewAccInputHashDoesNotExist",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NewPendingStateTimeoutMustBeLower",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NewTrustedAggregatorTimeoutMustBeLower",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotEnoughMaticAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OldAccInputHashDoesNotExist",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OldStateRootDoesNotExist",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyEmergencyState",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyNotEmergencyState",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyPendingAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyTrustedAggregator",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyTrustedSequencer",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PendingStateDoesNotExist",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PendingStateInvalid",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PendingStateNotConsolidable",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PendingStateTimeoutExceedHaltAggregationTimeout",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SequenceZeroBatches",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SequencedTimestampBelowForcedTimestamp",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SequencedTimestampInvalid",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "StoredRootMustBeDifferentThanNewRoot",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TransactionsLengthAboveMax",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TrustedAggregatorTimeoutExceedHaltAggregationTimeout",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TrustedAggregatorTimeoutNotExpired",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "AcceptAdminRole",
+    "type": "event"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -174,32 +418,6 @@
     "inputs": [
       {
         "indexed": false,
-        "internalType": "address",
-        "name": "newAdmin",
-        "type": "address"
-      }
-    ],
-    "name": "SetAdmin",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "newForceBatchAllowed",
-        "type": "bool"
-      }
-    ],
-    "name": "SetForceBatchAllowed",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
         "internalType": "uint16",
         "name": "newMultiplierBatchFee",
         "type": "uint16"
@@ -279,36 +497,49 @@
       {
         "indexed": false,
         "internalType": "uint64",
-        "name": "newVeryBatchTimeTarget",
+        "name": "newVerifyBatchTimeTarget",
         "type": "uint64"
       }
     ],
-    "name": "SetVeryBatchTimeTarget",
+    "name": "SetVerifyBatchTimeTarget",
     "type": "event"
   },
   {
     "anonymous": false,
     "inputs": [
       {
-        "indexed": true,
+        "indexed": false,
+        "internalType": "address",
+        "name": "newPendingAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "TransferAdminRole",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "uint64",
         "name": "numBatch",
         "type": "uint64"
       },
       {
         "indexed": false,
-        "internalType": "bytes32",
-        "name": "stateRoot",
-        "type": "bytes32"
+        "internalType": "uint64",
+        "name": "forkID",
+        "type": "uint64"
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "aggregator",
-        "type": "address"
+        "indexed": false,
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
       }
     ],
-    "name": "TrustedVerifyBatches",
+    "name": "UpdateZkEVMVersion",
     "type": "event"
   },
   {
@@ -337,68 +568,35 @@
     "type": "event"
   },
   {
-    "inputs": [],
-    "name": "FORCE_BATCH_TIMEOUT",
-    "outputs": [
+    "anonymous": false,
+    "inputs": [
       {
+        "indexed": true,
         "internalType": "uint64",
-        "name": "",
+        "name": "numBatch",
         "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "stateRoot",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "aggregator",
+        "type": "address"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "name": "VerifyBatchesTrustedAggregator",
+    "type": "event"
   },
   {
     "inputs": [],
-    "name": "HALT_AGGREGATION_TIMEOUT",
-    "outputs": [
-      {
-        "internalType": "uint64",
-        "name": "",
-        "type": "uint64"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "MAX_BATCH_MULTIPLIER",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "MAX_TRANSACTIONS_BYTE_LENGTH",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "MAX_VERIFY_BATCHES",
-    "outputs": [
-      {
-        "internalType": "uint64",
-        "name": "",
-        "type": "uint64"
-      }
-    ],
-    "stateMutability": "view",
+    "name": "acceptAdminRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -537,19 +735,6 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "forceBatchAllowed",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
         "internalType": "uint64",
@@ -563,6 +748,19 @@
         "internalType": "bytes32",
         "name": "",
         "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "forkID",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
       }
     ],
     "stateMutability": "view",
@@ -649,36 +847,11 @@
   {
     "inputs": [
       {
-        "internalType": "contract IPolygonZkEVMGlobalExitRoot",
-        "name": "_globalExitRootManager",
-        "type": "address"
-      },
-      {
-        "internalType": "contract IERC20Upgradeable",
-        "name": "_matic",
-        "type": "address"
-      },
-      {
-        "internalType": "contract IVerifierRollup",
-        "name": "_rollupVerifier",
-        "type": "address"
-      },
-      {
-        "internalType": "contract IPolygonZkEVMBridge",
-        "name": "_bridgeAddress",
-        "type": "address"
-      },
-      {
         "components": [
           {
             "internalType": "address",
             "name": "admin",
             "type": "address"
-          },
-          {
-            "internalType": "uint64",
-            "name": "chainID",
-            "type": "uint64"
           },
           {
             "internalType": "address",
@@ -689,11 +862,6 @@
             "internalType": "uint64",
             "name": "pendingStateTimeout",
             "type": "uint64"
-          },
-          {
-            "internalType": "bool",
-            "name": "forceBatchAllowed",
-            "type": "bool"
           },
           {
             "internalType": "address",
@@ -723,6 +891,11 @@
       {
         "internalType": "string",
         "name": "_networkName",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_version",
         "type": "string"
       }
     ],
@@ -961,6 +1134,19 @@
   },
   {
     "inputs": [],
+    "name": "pendingAdmin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "pendingStateTimeout",
     "outputs": [
       {
@@ -1107,6 +1293,11 @@
         "internalType": "struct PolygonZkEVM.BatchData[]",
         "name": "batches",
         "type": "tuple[]"
+      },
+      {
+        "internalType": "address",
+        "name": "feeRecipient",
+        "type": "address"
       }
     ],
     "name": "sequenceBatches",
@@ -1171,32 +1362,6 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newAdmin",
-        "type": "address"
-      }
-    ],
-    "name": "setAdmin",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bool",
-        "name": "newForceBatchAllowed",
-        "type": "bool"
-      }
-    ],
-    "name": "setForceBatchAllowed",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1281,11 +1446,24 @@
     "inputs": [
       {
         "internalType": "uint64",
-        "name": "newVeryBatchTimeTarget",
+        "name": "newVerifyBatchTimeTarget",
         "type": "uint64"
       }
     ],
-    "name": "setVeryBatchTimeTarget",
+    "name": "setVerifyBatchTimeTarget",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newPendingAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "transferAdminRole",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1356,51 +1534,16 @@
     "type": "function"
   },
   {
-    "inputs": [
+    "inputs": [],
+    "name": "verifyBatchTimeTarget",
+    "outputs": [
       {
         "internalType": "uint64",
-        "name": "pendingStateNum",
+        "name": "",
         "type": "uint64"
-      },
-      {
-        "internalType": "uint64",
-        "name": "initNumBatch",
-        "type": "uint64"
-      },
-      {
-        "internalType": "uint64",
-        "name": "finalNewBatch",
-        "type": "uint64"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "newLocalExitRoot",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "newStateRoot",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint256[2]",
-        "name": "proofA",
-        "type": "uint256[2]"
-      },
-      {
-        "internalType": "uint256[2][2]",
-        "name": "proofB",
-        "type": "uint256[2][2]"
-      },
-      {
-        "internalType": "uint256[2]",
-        "name": "proofC",
-        "type": "uint256[2]"
       }
     ],
-    "name": "trustedVerifyBatches",
-    "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -1452,16 +1595,51 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "veryBatchTimeTarget",
-    "outputs": [
+    "inputs": [
       {
         "internalType": "uint64",
-        "name": "",
+        "name": "pendingStateNum",
         "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "initNumBatch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "finalNewBatch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "newLocalExitRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "newStateRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[2]",
+        "name": "proofA",
+        "type": "uint256[2]"
+      },
+      {
+        "internalType": "uint256[2][2]",
+        "name": "proofB",
+        "type": "uint256[2][2]"
+      },
+      {
+        "internalType": "uint256[2]",
+        "name": "proofC",
+        "type": "uint256[2]"
       }
     ],
-    "stateMutability": "view",
+    "name": "verifyBatchesTrustedAggregator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   }
 ]

--- a/src/adapters/ethereum.ts
+++ b/src/adapters/ethereum.ts
@@ -34,8 +34,8 @@ const getBatchNumberOfL2Block = async (
   provider: JsonRpcProvider,
   blockNumber: number
 ): Promise<number> => {
-  const batchNumberOfL2Block: unknown = await provider.send("zkevm_batchNumberOfL2Block", [
-    blockNumber,
+  const batchNumberOfL2Block: unknown = await provider.send("zkevm_batchNumberByBlockNumber", [
+    ethersUtils.hexlify(blockNumber),
   ]);
   return z.number().parse(batchNumberOfL2Block);
 };

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -38,10 +38,6 @@ import { serializeBridgeId } from "src/utils/serializers";
 import { isTokenEther, selectTokenAddress } from "src/utils/tokens";
 import { isAsyncTaskDataAvailable } from "src/utils/types";
 
-interface GetMaxEtherBridgeParams {
-  chain: Chain;
-}
-
 interface EstimateBridgeGasParams {
   destinationAddress: string;
   from: Chain;
@@ -111,7 +107,6 @@ interface BridgeContext {
     bridges: Bridge[];
     total: number;
   }>;
-  getMaxEtherBridge: (params: GetMaxEtherBridgeParams) => Promise<BigNumber>;
   getPendingBridges: (bridges?: Bridge[]) => Promise<PendingBridge[]>;
 }
 
@@ -133,9 +128,6 @@ const bridgeContext = createContext<BridgeContext>({
   fetchBridges: () => {
     return Promise.reject(bridgeContextNotReadyErrorMsg);
   },
-  getMaxEtherBridge: () => {
-    return Promise.reject(bridgeContextNotReadyErrorMsg);
-  },
   getPendingBridges: () => {
     return Promise.reject(bridgeContextNotReadyErrorMsg);
   },
@@ -146,13 +138,6 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
   const { changeNetwork, connectedProvider } = useProvidersContext();
   const { addWrappedToken, getToken } = useTokensContext();
   const { getTokenPrice } = usePriceOracleContext();
-
-  const getMaxEtherBridge = useCallback(
-    ({ chain }: GetMaxEtherBridgeParams): Promise<BigNumber> => {
-      return Bridge__factory.connect(chain.bridgeContractAddress, chain.provider).maxEtherBridge();
-    },
-    []
-  );
 
   type Price = BigNumber | null;
   type TokenPrices = Partial<Record<string, Price>>;
@@ -905,18 +890,9 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
       estimateBridgeGas,
       fetchBridge,
       fetchBridges,
-      getMaxEtherBridge,
       getPendingBridges,
     }),
-    [
-      getMaxEtherBridge,
-      estimateBridgeGas,
-      fetchBridge,
-      fetchBridges,
-      getPendingBridges,
-      bridge,
-      claim,
-    ]
+    [estimateBridgeGas, fetchBridge, fetchBridges, getPendingBridges, bridge, claim]
   );
 
   return <bridgeContext.Provider value={value} {...props} />;

--- a/src/views/activity/components/bridge-card/bridge-card.styles.ts
+++ b/src/views/activity/components/bridge-card/bridge-card.styles.ts
@@ -68,6 +68,7 @@ export const useBridgeCardStyles = createUseStyles((theme: Theme) => ({
     marginLeft: theme.spacing(2),
   },
   infoContainer: {
+    alignItems: "center",
     display: "flex",
     flex: 1,
   },

--- a/src/views/bridge-confirmation/bridge-confirmation.styles.ts
+++ b/src/views/bridge-confirmation/bridge-confirmation.styles.ts
@@ -42,8 +42,13 @@ export const useBridgeConfirmationStyles = createUseStyles((theme: Theme) => ({
     flex: 1,
     gap: theme.spacing(1),
     justifyContent: "center",
-    maxWidth: 260,
+    maxWidth: 240,
     padding: [theme.spacing(1), theme.spacing(2)],
+  },
+  chainName: {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
   chainsRow: {
     alignItems: "center",

--- a/src/views/bridge-confirmation/bridge-confirmation.styles.ts
+++ b/src/views/bridge-confirmation/bridge-confirmation.styles.ts
@@ -42,7 +42,7 @@ export const useBridgeConfirmationStyles = createUseStyles((theme: Theme) => ({
     flex: 1,
     gap: theme.spacing(1),
     justifyContent: "center",
-    maxWidth: 240,
+    maxWidth: 260,
     padding: [theme.spacing(1), theme.spacing(2)],
   },
   chainsRow: {

--- a/src/views/bridge-confirmation/bridge-confirmation.view.tsx
+++ b/src/views/bridge-confirmation/bridge-confirmation.view.tsx
@@ -439,12 +439,16 @@ export const BridgeConfirmation: FC = () => {
         <div className={classes.chainsRow}>
           <div className={classes.chainBox}>
             <from.Icon />
-            <Typography type="body1">{from.name}</Typography>
+            <Typography className={classes.chainName} type="body1">
+              {from.name}
+            </Typography>
           </div>
           <ArrowRightIcon className={classes.arrowIcon} />
           <div className={classes.chainBox}>
             <to.Icon />
-            <Typography type="body1">{to.name}</Typography>
+            <Typography className={classes.chainName} type="body1">
+              {to.name}
+            </Typography>
           </div>
         </div>
         <div className={classes.feeBlock}>

--- a/src/views/home/components/amount-input/amount-input.view.tsx
+++ b/src/views/home/components/amount-input/amount-input.view.tsx
@@ -2,42 +2,26 @@ import { BigNumber } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import { ChangeEvent, FC, useEffect, useState } from "react";
 
-import { Chain, Token } from "src/domain";
+import { Token } from "src/domain";
 import { formatTokenAmount } from "src/utils/amounts";
-import { isTokenEther } from "src/utils/tokens";
 import { useAmountInputStyles } from "src/views/home/components/amount-input/amount-input.styles";
 import { Typography } from "src/views/shared/typography/typography.view";
 
 interface AmountInputProps {
   balance: BigNumber;
-  from: Chain;
-  maxEtherBridge: BigNumber;
   onChange: (params: { amount?: BigNumber; error?: string }) => void;
   token: Token;
   value?: BigNumber;
 }
 
-export const AmountInput: FC<AmountInputProps> = ({
-  balance,
-  from,
-  maxEtherBridge,
-  onChange,
-  token,
-  value,
-}) => {
+export const AmountInput: FC<AmountInputProps> = ({ balance, onChange, token, value }) => {
   const defaultInputValue = value ? formatTokenAmount(value, token) : "";
   const [inputValue, setInputValue] = useState(defaultInputValue);
   const classes = useAmountInputStyles(inputValue.length);
-  const shouldApplyMaxEtherBridgeLimit = isTokenEther(token) && from.key === "ethereum";
 
   const processOnChangeCallback = (amount?: BigNumber) => {
     if (amount) {
-      const balanceError = amount.gt(balance) ? "Insufficient balance" : undefined;
-      const maxEtherBridgeError =
-        shouldApplyMaxEtherBridgeLimit && amount.gt(maxEtherBridge)
-          ? "Amount exceeds the max allowed to bridge"
-          : undefined;
-      const error = balanceError || maxEtherBridgeError;
+      const error = amount.gt(balance) ? "Insufficient balance" : undefined;
 
       return onChange({ amount, error });
     } else {
@@ -60,11 +44,9 @@ export const AmountInput: FC<AmountInputProps> = ({
   };
 
   const onMax = () => {
-    const maxPossibleAmount =
-      shouldApplyMaxEtherBridgeLimit && balance.gt(maxEtherBridge) ? maxEtherBridge : balance;
-    if (maxPossibleAmount.gt(0)) {
-      setInputValue(formatTokenAmount(maxPossibleAmount, token));
-      processOnChangeCallback(maxPossibleAmount);
+    if (balance.gt(0)) {
+      setInputValue(formatTokenAmount(balance, token));
+      processOnChangeCallback(balance);
     } else {
       setInputValue("");
       processOnChangeCallback();

--- a/src/views/home/components/bridge-form/bridge-form.view.tsx
+++ b/src/views/home/components/bridge-form/bridge-form.view.tsx
@@ -27,7 +27,6 @@ import { Typography } from "src/views/shared/typography/typography.view";
 interface BridgeFormProps {
   account: string;
   formData?: FormData;
-  maxEtherBridge?: BigNumber;
   onResetForm: () => void;
   onSubmit: (formData: FormData) => void;
 }
@@ -37,13 +36,7 @@ interface SelectedChains {
   to: Chain;
 }
 
-export const BridgeForm: FC<BridgeFormProps> = ({
-  account,
-  formData,
-  maxEtherBridge,
-  onResetForm,
-  onSubmit,
-}) => {
+export const BridgeForm: FC<BridgeFormProps> = ({ account, formData, onResetForm, onSubmit }) => {
   const classes = useBridgeFormStyles();
   const callIfMounted = useCallIfMounted();
   const env = useEnvContext();
@@ -268,7 +261,7 @@ export const BridgeForm: FC<BridgeFormProps> = ({
     }
   }, [formData, onResetForm]);
 
-  if (!env || !selectedChains || !tokens || !token || !maxEtherBridge) {
+  if (!env || !selectedChains || !tokens || !token) {
     return (
       <div className={classes.spinner}>
         <Spinner />
@@ -313,8 +306,6 @@ export const BridgeForm: FC<BridgeFormProps> = ({
                 ? balanceFrom.data
                 : BigNumber.from(0)
             }
-            from={selectedChains.from}
-            maxEtherBridge={maxEtherBridge}
             onChange={onAmountInputChange}
             token={token}
             value={amount}

--- a/src/views/home/home.styles.ts
+++ b/src/views/home/home.styles.ts
@@ -19,9 +19,6 @@ export const useHomeStyles = createUseStyles((theme: Theme) => ({
       margin: [theme.spacing(3), "auto", theme.spacing(5)],
     },
   },
-  maxEtherBridgeInfo: {
-    margin: [0, "auto", theme.spacing(3)],
-  },
   metaMaskIcon: {
     marginRight: theme.spacing(1),
     width: 20,

--- a/src/views/home/home.view.tsx
+++ b/src/views/home/home.view.tsx
@@ -1,19 +1,14 @@
-import { BigNumber, utils as ethersUtils } from "ethers";
-import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { ReactComponent as MetaMaskIcon } from "src/assets/icons/metamask.svg";
-import { useBridgeContext } from "src/contexts/bridge.context";
-import { useEnvContext } from "src/contexts/env.context";
 import { useFormContext } from "src/contexts/form.context";
 import { useProvidersContext } from "src/contexts/providers.context";
-import { EthereumChainId, FormData } from "src/domain";
+import { FormData } from "src/domain";
 import { routes } from "src/routes";
 import { getPartiallyHiddenEthereumAddress } from "src/utils/addresses";
 import { BridgeForm } from "src/views/home/components/bridge-form/bridge-form.view";
 import { Header } from "src/views/home/components/header/header.view";
 import { useHomeStyles } from "src/views/home/home.styles";
-import { InfoBanner } from "src/views/shared/info-banner/info-banner.view";
 import { NetworkBox } from "src/views/shared/network-box/network-box.view";
 import { Typography } from "src/views/shared/typography/typography.view";
 
@@ -21,9 +16,6 @@ export const Home = (): JSX.Element => {
   const classes = useHomeStyles();
   const navigate = useNavigate();
   const { formData, setFormData } = useFormContext();
-  const env = useEnvContext();
-  const { getMaxEtherBridge } = useBridgeContext();
-  const [maxEtherBridge, setMaxEtherBridge] = useState<BigNumber>();
   const { connectedProvider } = useProvidersContext();
 
   const onFormSubmit = (formData: FormData) => {
@@ -34,16 +26,6 @@ export const Home = (): JSX.Element => {
   const onResetForm = () => {
     setFormData(undefined);
   };
-
-  useEffect(() => {
-    if (env) {
-      void getMaxEtherBridge({ chain: env.chains[0] })
-        .then(setMaxEtherBridge)
-        .catch(() => {
-          setMaxEtherBridge(ethersUtils.parseEther("0.25"));
-        });
-    }
-  }, [env, getMaxEtherBridge]);
 
   return (
     <div className={classes.contentWrapper}>
@@ -59,18 +41,9 @@ export const Home = (): JSX.Element => {
           <div className={classes.networkBoxWrapper}>
             <NetworkBox />
           </div>
-          <InfoBanner
-            className={classes.maxEtherBridgeInfo}
-            message={`ETH bridges in the ${
-              EthereumChainId.GOERLI === env?.chains[0].chainId ? "Ethereum Goerli" : "Ethereum"
-            } network are limited to ${
-              maxEtherBridge ? ethersUtils.formatEther(maxEtherBridge) : "--"
-            } ETH in early testnet versions`}
-          />
           <BridgeForm
             account={connectedProvider.data.account}
             formData={formData}
-            maxEtherBridge={maxEtherBridge}
             onResetForm={onResetForm}
             onSubmit={onFormSubmit}
           />


### PR DESCRIPTION
### What does this PR does?

This PR updates the ABIs of the Bridge and PoE smart contracts. It removes the `maxEtherBridge` call as well and widens the `chainBox` a little bit to support longer chain names like the new zkEVM one.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [x] Update documentation (if needed)
