### PR TITLE
Add support for the new `forceUpdateGlobalExitRoot` param of the `bridgeAsset` method

### DIFF
--- a/abis/bridge.json
+++ b/abis/bridge.json
@@ -237,11 +237,6 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
         "internalType": "uint32",
         "name": "destinationNetwork",
         "type": "uint32"
@@ -255,6 +250,16 @@
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "forceUpdateGlobalExitRoot",
+        "type": "bool"
       },
       {
         "internalType": "bytes",
@@ -278,6 +283,11 @@
         "internalType": "address",
         "name": "destinationAddress",
         "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "forceUpdateGlobalExitRoot",
+        "type": "bool"
       },
       {
         "internalType": "bytes",
@@ -601,6 +611,19 @@
   },
   {
     "inputs": [],
+    "name": "lastUpdatedDepositCount",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "networkID",
     "outputs": [
       {
@@ -681,6 +704,13 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "updateGlobalExitRoot",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -681,11 +681,20 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
         : { from: destinationAddress };
 
       const tokenAddress = selectTokenAddress(token, from);
+      const forceUpdateGlobalExitRoot = from.key === "polygon-zkevm";
 
       const gasLimit =
         from.key === "ethereum"
           ? await contract.estimateGas
-              .bridgeAsset(tokenAddress, to.networkId, destinationAddress, amount, "0x", overrides)
+              .bridgeAsset(
+                to.networkId,
+                destinationAddress,
+                amount,
+                tokenAddress,
+                forceUpdateGlobalExitRoot,
+                "0x",
+                overrides
+              )
               .then((gasLimit) => {
                 const gasLimitIncrease = gasLimit
                   .div(BigNumber.from(100))
@@ -763,12 +772,15 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
               })
             : "0x";
 
+        const forceUpdateGlobalExitRoot = from.key === "polygon-zkevm";
+
         return contract
           .bridgeAsset(
-            selectTokenAddress(token, from),
             to.networkId,
             destinationAddress,
             amount,
+            selectTokenAddress(token, from),
+            forceUpdateGlobalExitRoot,
             permitData,
             overrides
           )


### PR DESCRIPTION
Closes #257 

The method `bridgeAsset` now includes a new boolean param `forceUpdateGlobalExitRoot`. At this iteration the value for the param depends solely on the origin network of the bridge:

* Bridges initiated on L1: `false` 
* Bridges initiated on L2: `true`

In a future iteration, the node team may implement a feature that allows us to optimize this further but for now, we will send `true` for L2 bridges.

Notice also that the `token` param has its position changed.