### PR TITLE
chore: rename `handler` → `timeoutID`

### DIFF
--- a/src/hooks/use-debounce.ts
+++ b/src/hooks/use-debounce.ts
@@ -4,12 +4,12 @@ export function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
   useEffect(() => {
-    const handler = setTimeout(() => {
+    const timeoutID = setTimeout(() => {
       setDebouncedValue(value);
     }, delay);
 
     return () => {
-      clearTimeout(handler);
+      clearTimeout(timeoutID);
     };
   }, [value, delay]);
 


### PR DESCRIPTION
Closes #NA

### What does this PR does?

- Rename `handler` → `timeoutID` in `src/hooks/use-debounce.ts`
- the `setTimeout()` returns `timeoutID` a **positive integer** and not a `handler`
- ref: https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#return_value

### How to test?

- CI should be green 🟢

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [-] Update documentation (if needed)
